### PR TITLE
Feature/0.8.0 \\. Syntax

### DIFF
--- a/examples/http/src/example.module.ts
+++ b/examples/http/src/example.module.ts
@@ -14,6 +14,7 @@ const contextConfig = {
   type: ContextName.HTTP,
   build: {
     'multi_level.value': ['my-value'],
+    'single_level\\.value': ['my-value'],
     host_from_header: ['req.headers.host'],
     environment_from_value_or_query_or_header: [
       'req.headers.environment',

--- a/src/context/add-context-defaults.ts
+++ b/src/context/add-context-defaults.ts
@@ -35,11 +35,9 @@ const createHttpContextDefaults = (config: Partial<ContextConfigType>) => {
     [CONTEXT_BIN]: [
       process.argv?.[1]
         ? basename(process.argv[1], extname(process.argv[1]))
-        : `${hostname()}_${process.argv?.[0] || 'unknown'}`,
+        : `${hostname()}_${process.argv?.[0] || null}`,
     ],
-    [CONTEXT_PATH]: [
-      (req: Request) => (req ? req.baseUrl + req.path : 'unknown'),
-    ],
+    [CONTEXT_PATH]: [(req: Request) => (req ? req.baseUrl + req.path : null)],
     [CONTEXT_PROTOCOL]: ['req.protocol'],
     [CONTEXT_CONTENT_TYPE]: [`req.${HttpProp.HEADERS}.${HEADER_CONTENT_TYPE}`],
   };

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -101,7 +101,12 @@ export class Context {
       return context;
     }
     for (const key of Object.keys(this.build)) {
-      set(context, key, this.get(key));
+      // TODO this only works with \\. OR ., but not for both
+      if (key.includes('\\.')) {
+        context[key.replace('\\.', '.')] = this.get(key);
+      } else {
+        set(context, key, this.get(key));
+      }
     }
     // this.logger.debug(`Got context ${JSON.stringify(context)}`);
     return includeNull

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -103,7 +103,7 @@ export class Context {
     for (const key of Object.keys(this.build)) {
       set(context, key, this.get(key));
     }
-    this.logger.debug(`Got context ${JSON.stringify(context)}`);
+    // this.logger.debug(`Got context ${JSON.stringify(context)}`);
     return includeNull
       ? context
       : pickBy(context, (ctx) => ctx !== null && ctx !== undefined);

--- a/src/interceptors/context-request.interceptor.ts
+++ b/src/interceptors/context-request.interceptor.ts
@@ -10,17 +10,21 @@ import { tap } from 'rxjs/operators';
 import { Context, getContextRequest } from '../context';
 import { CONTEXT_MODULE_CONFIG } from '../constants';
 import { ContextConfigType } from '../interfaces';
+import { Logger } from '@nestjs/common';
 
 @Injectable()
 export class ContextRequestInterceptor implements NestInterceptor {
+  private logger = new Logger(ContextRequestInterceptor.name);
   constructor(
     private readonly context: Context,
     @Inject(CONTEXT_MODULE_CONFIG) private readonly config: ContextConfigType,
   ) {}
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     this.context.setRequest(getContextRequest(this.config.type, context));
+    this.logger.debug(`Context request set: ${!!this.context.request}`);
     return next.handle().pipe(
       tap(() => {
+        this.logger.debug('Clear context...');
         this.context.setRequest(null);
         this.context.clear();
       }),


### PR DESCRIPTION
Added \\. Syntax to avoid lodash set to be used in context. This is useful when you want to include context keys with dots inside.